### PR TITLE
raise starlit/validation version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=7.0",
         "starlit/db": "~0.8",
-        "starlit/validation": "~0.1"
+        "starlit/validation": "~0.2"
 
     },
     "require-dev": {


### PR DESCRIPTION
This PR updates the `starlit/validation` requirement to the latest `0.2` version