### PR TITLE
DbEntityDataValidator: Remove strict declaration

### DIFF
--- a/src/DbEntityDataValidator.php
+++ b/src/DbEntityDataValidator.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 /**
  * Db data validation.
  *


### PR DESCRIPTION
Remove strict declaration due to too big backward compatibility break